### PR TITLE
Fix Bug in Downloads button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ links:
   - title: Documents
     url: /documents
   - title: Downloads
-    url: http://necrobot2.com/documents/#Releases
+    url: /documents/#Releases
     external: false
   - title: About
     url: /about

--- a/_config.yml
+++ b/_config.yml
@@ -47,7 +47,6 @@ links:
     url: /documents
   - title: Downloads
     url: /documents/#Releases
-    external: false
   - title: About
     url: /about
   - title: Donate


### PR DESCRIPTION
## Short Desc
On clicking the Downloads Button you get redirected to http://necrobot2.comhttp//necrobot2.com/documents/#Releases
rather http://necrobot2.com/documents/#Releases
This fixes this Issue